### PR TITLE
Updatedocker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,33 @@
 FROM ubuntu:latest
-RUN apt-get update && \
-    apt-get install -y sudo curl git build-essential python3-pip python3-distutils gcc-arm-none-eabi binutils-arm-none-eabi g++ clang && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN useradd -m -s /bin/bash -u 1002 aeroriver && \
-    usermod -aG sudo aeroriver && \
-    echo "aeroriver ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-
 WORKDIR /app
 
-USER aeroriver 
+ARG USER_NAME="aeroriver"
+ARG OPT="/opt"
+ARG PKGS="sudo curl git g++ wget build-essential bash-completion ccache g++-arm-linux-gnueabihf python3-pip python3-distutils"
+ARG ARM_ROOT="gcc-arm-none-eabi-10-2020-q4-major"
+
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    $PKGS && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN cd $OPT && \
+    sudo wget --no-check-certificate --progress=dot:giga https://firmware.ardupilot.org/Tools/STM32-tools/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2 && \
+    sudo chmod -R 777 gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2 && \
+    sudo tar xjf gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2 && \
+    sudo rm gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2 && \
+    sudo ln -s -f $(which ccache) /usr/lib/ccache/arm-none-eabi-g++ && \
+    sudo ln -s -f $(which ccache) /usr/lib/ccache/arm-none-eabi-gcc
+    
+ENV PATH="${OPT}/gcc-arm-none-eabi-10-2020-q4-major/bin:${PATH}"
+
+RUN useradd -m -s /bin/bash -u 1002 $USER_NAME && \
+    usermod -aG sudo $USER_NAME && \
+    echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+USER $USER_NAME 
 
 RUN pip install --user empy==3.3.4 pexpect future
-
-ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
-ENV CC=/usr/bin/gcc
-ENV CXX=/usr/bin/g++
 
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 
 ARG USER_NAME="aeroriver"
 ARG OPT="/opt"
-ARG PKGS="sudo curl git g++ wget build-essential bash-completion ccache g++-arm-linux-gnueabihf python3-pip python3-distutils"
+ARG PKGS="sudo curl git g++ wget build-essential ccache g++-arm-linux-gnueabihf python3-pip python3-distutils"
 ARG ARM_ROOT="gcc-arm-none-eabi-10-2020-q4-major"
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 
 ARG USER_NAME="aeroriver"
 ARG OPT="/opt"
-ARG PKGS="sudo curl git g++ wget build-essential ccache g++-arm-linux-gnueabihf python3-pip python3-distutils"
+ARG PKGS="sudo git g++ wget build-essential ccache g++-arm-linux-gnueabihf python3-pip python3-distutils"
 ARG ARM_ROOT="gcc-arm-none-eabi-10-2020-q4-major"
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,8 @@ USER $USER_NAME
 
 RUN pip install --user empy==3.3.4 pexpect future
 
+RUN sudo apt-get clean && \
+    sudo apt-get autoclean && \
+    sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 CMD ["bash"]


### PR DESCRIPTION
A configuração Docker previamente utilizada funcionava corretamente para copilar o ardupilot para o SITL, entretanto notou um erro ao compilar para boards em hardware, como Pixhawk1, pois alguns pacotes e variáveis de ambiente estavam incorretos o que causava falha na criação dos executáveis e binários do ardupilot para essas placas. Após um estudo profundo sobre os scripts de ambiente do ardupilot, foi possível construir um ambiente virtual leve e rápido que contém todos pacotes e configurações de ambiente necessários para a compilação do projeto ardupilot para todas as boards. Algumas das alterações incluem:

- Instalação e configuração correta do pacote do compilador arm-none-eabi
- Instalação da versão correta do compilador gcc e g++
- Adicionado um passo extra para limpeza de cache de variáveis temporárias.

---

Pedro Masteguin